### PR TITLE
5 - ensure 'generate report' form inputs initiate as unpopulated.

### DIFF
--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -695,7 +695,9 @@
                         "label": "Context",
                         "explanation": "Use this space to briefly describe the main rights-holders and other actors in this area, the key governance and management challenges, and any other factors that you think shape the social and ecological outcomes of the area."
                     },
-                    "button": "Generate"
+                    "button": "Generate",
+                    "buttonGenerating": "Generating...",
+                    "error": "There was an error generating the report."
                 }
             },
             "outOf100": "out of 100",

--- a/locales/es/translations.json
+++ b/locales/es/translations.json
@@ -690,7 +690,9 @@
                         "label": "Context",
                         "explanation": "Use this space to briefly describe the main rights-holders and other actors in this area, the key governance and management challenges, and any other factors that you think shape the social and ecological outcomes of the area."
                     },
-                    "button": "Generate"
+                    "button": "Generate",
+                    "buttonGenerating": "Generando...",
+                    "error": "Hubo un error al generar el informe."
                 }
             },
             "outOf100": "out of 100",

--- a/locales/id/translations.json
+++ b/locales/id/translations.json
@@ -690,7 +690,9 @@
                         "label": "Context",
                         "explanation": "Use this space to briefly describe the main rights-holders and other actors in this area, the key governance and management challenges, and any other factors that you think shape the social and ecological outcomes of the area."
                     },
-                    "button": "Generate"
+                    "button": "Generate",
+                    "buttonGenerating": "Menghasilkan...",
+                    "error": "Terjadi kesalahan saat membuat laporan."
                 }
             },
             "outOf100": "out of 100",

--- a/locales/pt/translations.json
+++ b/locales/pt/translations.json
@@ -690,7 +690,9 @@
                         "label": "Context",
                         "explanation": "Use this space to briefly describe the main rights-holders and other actors in this area, the key governance and management challenges, and any other factors that you think shape the social and ecological outcomes of the area."
                     },
-                    "button": "Generate"
+                    "button": "Generate",
+                    "buttonGenerating": "Gerando...",
+                    "error": "Ocorreu um erro ao gerar o relatório."
                 }
             },
             "outOf100": "de 100",

--- a/locales/sw/translations.json
+++ b/locales/sw/translations.json
@@ -679,7 +679,9 @@
                         "label": "Muktadha",
                         "explanation": "Tumia nafasi hii kuelezea kwa ufupi wamiliki wakuu wa haki na wahusika wengine katika eneo hili, changamoto kuu za utawala na usimamizi, na mambo mengine yoyote ambayo unafikiri yanaunda matokeo ya kijamii na kiikolojia ya eneo hilo."
                     },
-                    "button": "Toa ripoti"
+                    "button": "Toa ripoti",
+                    "buttonGenerating": "Inazalisha...",
+                    "error": "Kulikuwa na hitilafu katika kuzalisha ripoti."
                 },
                 "delete": {
                     "title": "Futa kichwa",

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -58,6 +58,7 @@ export default async () => {
             '~/plugins/formDataStringify.js',
             '~/plugins/vue-date-picker.js',
             '~/plugins/scoreColors.js',
+            '~/plugins/vue-toasted.js',
             {
                 src: '~/plugins/choices.js',
                 mode: 'client',

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "vue-mapbox": "^0.4.1",
         "vue-multiselect": "^2.1.6",
         "vue-select": "^3.11.2",
+        "vue-toasted": "^1.1.28",
         "vue2-leaflet": "^2.7.1",
         "vuejs-datepicker": "^1.6.2",
         "vuex-persist": "^3.1.3"

--- a/plugins/vue-toasted.js
+++ b/plugins/vue-toasted.js
@@ -1,0 +1,8 @@
+import Vue from 'vue';
+import Toasted from 'vue-toasted';
+
+Vue.use(Toasted, {
+    theme: 'bubble',
+    position: 'bottom-right',
+    duration: 7000,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11618,6 +11618,11 @@ vue-tippy@^4.10.1:
     humps "^2.0.1"
     tippy.js "^4.3.5"
 
+vue-toasted@^1.1.28:
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/vue-toasted/-/vue-toasted-1.1.28.tgz#dbabb83acc89f7a9e8765815e491d79f0dc65c26"
+  integrity sha512-UUzr5LX51UbbiROSGZ49GOgSzFxaMHK6L00JV8fir/CYNJCpIIvNZ5YmS4Qc8Y2+Z/4VVYRpeQL2UO0G800Raw==
+
 vue2-dropzone@3.6.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/vue2-dropzone/-/vue2-dropzone-3.6.0.tgz"


### PR DESCRIPTION
Work completed:
- ensure the 'generate report' form for an assessment is unpopulated when the form is first shown
- if there is an error generating the report, show an error message to the user
- when the report generation is in progress, update the botton text to 'Generating...' to indicate to the user that something is happening

<img width="1726" alt="Screenshot 2024-12-05 at 1 13 40 PM" src="https://github.com/user-attachments/assets/c5fe20e7-619d-419e-8052-009aafbd4bc3">
