### PR TITLE
16 fix search results persistence issue

### DIFF
--- a/plugins/vuex-persist.js
+++ b/plugins/vuex-persist.js
@@ -2,8 +2,17 @@ import VuexPersistence from 'vuex-persist';
 
 export default ({ store }) => {
     new VuexPersistence({
-        filter: (mutation) => {
-            mutation.type !== 'setSearch'; // do not persist assessments page search text
+        reducer: (state) => {
+            const stateCopy = { ...state };
+
+            if (stateCopy.assessments) {
+                // remove search property from state
+                const { search, ...assessmentsPropertiesToPersist } =
+                    stateCopy.assessments;
+                stateCopy.assessments = assessmentsPropertiesToPersist;
+            }
+
+            return stateCopy;
         },
     }).plugin(store);
 };


### PR DESCRIPTION
This fix is a redo to ensure the assessments page search text and results dont persist through a browser refresh