### PR TITLE
8 handle api responses

### DIFF
--- a/components/popup/popup-assessment-generate-report.vue
+++ b/components/popup/popup-assessment-generate-report.vue
@@ -353,7 +353,7 @@ export default {
                 })
                 .catch(() => {
                     this.isReportGenerating = false;
-                    this.$toasted.error(
+                    this.$toast.error(
                         this.$t(
                             'pages.assessments.actions.generateReport.error',
                         ),

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -1,4 +1,19 @@
 {
+    "statusMessaging": {
+        "assessments": {
+            "publishingAssessmentError": "Error publishing assessment.",
+            "publishingAssessmentSuccess": "Assessment published successfully.",
+            "unpublishingAssessmentError": "Error unpublishing assessment.",
+            "unpublishingAssessmentSuccess": "Assessment unpublished successfully."
+        },
+        "authentication": {
+            "logoutError": "You are currently logged out."
+        },
+        "organizations": {
+            "organizationCreatedSuccess": "Institution created successfully.",
+            "organizationCreatedError": "Error creating institution."
+        }
+    },
     "pages": {
         "home": {
             "meta": {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -58,12 +58,12 @@ export default async () => {
             '~/plugins/formDataStringify.js',
             '~/plugins/vue-date-picker.js',
             '~/plugins/scoreColors.js',
-            '~/plugins/vue-toasted.js',
             {
                 src: '~/plugins/choices.js',
                 mode: 'client',
             },
             { src: '~/plugins/vuex-persist', ssr: false },
+            '~/plugins/axios.js',
         ],
         buildModules: [
             '@nuxtjs/tailwindcss',
@@ -99,6 +99,7 @@ export default async () => {
             'nuxt-vue-multiselect',
             '@nuxtjs/google-gtag',
             '@nuxtjs/recaptcha',
+            '@nuxtjs/toast',
         ],
         auth: {
             strategies: {
@@ -208,6 +209,11 @@ export default async () => {
                 // cacheAssets: true,
                 offlineStrategy: 'CacheFirst',
             },
+        },
+        toast: {
+            theme: 'bubble',
+            position: 'bottom-right',
+            duration: 7000,
         },
     };
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "@nuxtjs/google-gtag": "^1.0.4",
         "@nuxtjs/moment": "^1.6.1",
         "@nuxtjs/recaptcha": "^1.1.1",
+        "@nuxtjs/toast": "^3.3.1",
         "@turf/turf": "^6.4.0",
         "core-js": "^3.9.1",
         "countries-api": "^2.0.2",
@@ -32,7 +33,6 @@
         "vue-mapbox": "^0.4.1",
         "vue-multiselect": "^2.1.6",
         "vue-select": "^3.11.2",
-        "vue-toasted": "^1.1.28",
         "vue2-leaflet": "^2.7.1",
         "vuejs-datepicker": "^1.6.2",
         "vuex-persist": "^3.1.3"

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,0 +1,12 @@
+export default function ({ $axios, app, store, $nuxt }) {
+    $axios.onError((error) => {
+        if (error.response.status === 401) {
+            store.dispatch('loader/loaderState', { active: false });
+            app.$auth.logout();
+            app.$toast.info(
+                app.i18n.t('statusMessaging.authentication.logoutError'),
+            );
+        }
+        throw error;
+    });
+}

--- a/plugins/vue-toasted.js
+++ b/plugins/vue-toasted.js
@@ -1,8 +1,0 @@
-import Vue from 'vue';
-import Toasted from 'vue-toasted';
-
-Vue.use(Toasted, {
-    theme: 'bubble',
-    position: 'bottom-right',
-    duration: 7000,
-});

--- a/store/assessments.js
+++ b/store/assessments.js
@@ -432,6 +432,7 @@ export const actions = {
             active: true,
             text: 'Publishing assessment...',
         });
+        this.dispatch('popup/popupState', { active: false });
         const versionResponse = await this.$axios.get('v2/assessmentversion');
         const published_version = versionResponse.data;
         this.$axios({
@@ -439,17 +440,25 @@ export const actions = {
             url: `/v2/assessments/${id}/`,
             data: { data_policy: 90, published_version },
         })
-            .then((response) => {
+            .then(() => {
                 state.commit('setAssessmentField', {
                     field: 'data_policy',
                     value: 90,
                 });
                 state.commit('setLastEdit');
-                this.dispatch('popup/popupState', { active: false });
                 this.$router.push('/assessments');
+                this.$toast.success(
+                    this.$i18n.t(
+                        'statusMessaging.assessments.unpublishingAssessmentSuccess',
+                    ),
+                );
             })
-            .catch((error) => {
-                console.log(error);
+            .catch(() => {
+                this.$toast.error(
+                    this.$i18n.t(
+                        'statusMessaging.assessments.publishingAssessmentError',
+                    ),
+                );
             })
             .finally(() => {
                 this.dispatch('loader/loaderState', {
@@ -464,23 +473,31 @@ export const actions = {
             active: true,
             text: 'Unpublishing assessment...',
         });
-
+        this.dispatch('popup/popupState', { active: false });
         this.$axios({
             method: 'patch',
             url: `/v2/assessments/${id}/`,
             data: { data_policy: 10 },
         })
-            .then((response) => {
+            .then(() => {
                 state.commit('setAssessmentField', {
                     field: 'data_policy',
                     value: 10,
                 });
                 state.commit('setLastEdit');
-                this.dispatch('popup/popupState', { active: false });
                 this.$router.push('/assessments');
+                this.$toast.success(
+                    this.$i18n.t(
+                        'statusMessaging.assessments.unpublishingAssessmentSuccess',
+                    ),
+                );
             })
-            .catch((error) => {
-                console.log(error);
+            .catch(() => {
+                this.$toast.error(
+                    this.$i18n.t(
+                        'statusMessaging.assessments.unpublishingAssessmentError',
+                    ),
+                );
             })
             .finally(() => {
                 this.dispatch('loader/loaderState', {

--- a/store/organizations.js
+++ b/store/organizations.js
@@ -27,13 +27,29 @@ export const actions = {
         }
     },
     async createOrganization(state, name) {
-        const response = await this.$axios({
+        return this.$axios({
             method: 'post',
             url: 'v2/organizations/',
             data: { name },
-        });
-        const organization = response.data;
-        state.commit('addToList', organization);
-        return organization;
+        })
+            .then((response) => {
+                const organization = response.data;
+                state.commit('addToList', organization);
+                this.$toast.success(
+                    this.$i18n.t(
+                        'statusMessaging.organizations.organizationCreatedSuccess',
+                    ),
+                );
+                return organization;
+            })
+            .catch((error) => {
+                const errorMessage = error.response.data.name[0];
+
+                this.$toast.error(
+                    `${this.$i18n.t(
+                        'statusMessaging.organizations.organizationCreatedError',
+                    )} ${errorMessage}`,
+                );
+            });
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,6 +1558,13 @@
     tailwindcss "^2.2.2"
     ufo "^0.7.5"
 
+"@nuxtjs/toast@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/toast/-/toast-3.3.1.tgz#ae489f4990b5da9f7ab90ea2dbfcf47900cb3ca2"
+  integrity sha512-b9JpyjSw5ZOyjskBvNc4NEebe0qxB6LivBlO84gHOnsaF23rLkJoBfVNDcXwGNDl7vm09yM4WqBGTkm/OQ0ZCQ==
+  dependencies:
+    vue-toasted "^1.1.28"
+
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.npmjs.org/@nuxtjs/youch/-/youch-4.2.3.tgz"


### PR DESCRIPTION
This work includes handling:
- 401 responses, 
   - clears the loader
   - resets auth state
   - shows a toast to the user
- publishing and unpublishing an assessment, 
   - clears the popup earlier so that the user can see the status text  ( Example: "Publishing assessment...")
   - adds a 'success' toast on success
   - adds a 'error' toast on error
- and creating a new institution (including when an institution already exists)
   - adds a 'success' toast on success
   - adds a 'error' toast on error

