### PR TITLE
226 offline surver session message

### DIFF
--- a/components/assessment/assessment-actions.vue
+++ b/components/assessment/assessment-actions.vue
@@ -11,7 +11,10 @@
         >
         <template v-if="$auth.loggedIn">
             <a
-                v-if="isAssessmentCollaborator($auth, assessment) && !isOffline"
+                v-if="
+                    isAssessmentCollaborator($auth, assessment) &&
+                    !isSurveyOffline
+                "
                 @click="
                     popupState({
                         active: true,
@@ -34,7 +37,7 @@
             </a>
             <a
                 v-if="
-                    !isOffline &&
+                    !isSurveyOffline &&
                     isAssessmentCollaborator($auth, assessment) &&
                     !isAssessmentObserver($auth, assessment)
                 "
@@ -50,7 +53,7 @@
             >
             <a
                 v-if="
-                    !isOffline &&
+                    !isSurveyOffline &&
                     isAssessmentCollaborator($auth, assessment) &&
                     !isAssessmentObserver($auth, assessment)
                 "
@@ -75,10 +78,10 @@
                         stroke-linejoin="round"
                     />
                 </svg>
-                <span> Turn {{ isOffline ? 'online' : 'offline' }} </span>
+                <span> Turn {{ isSurveyOffline ? 'online' : 'offline' }} </span>
             </a>
             <a
-                v-if="!isCreator() && !isOffline"
+                v-if="!isCreator() && !isSurveyOffline"
                 @click="contact"
                 role="button"
                 class="btn btn--border-turqy btn--sm"
@@ -87,7 +90,7 @@
                 <span>{{ $t('default.contactAdministrator') }}</span></a
             >
             <a
-                v-if="!isCreator() && !isOffline"
+                v-if="!isCreator() && !isSurveyOffline"
                 @click="flag"
                 role="button"
                 class="btn btn--rounded"
@@ -98,7 +101,9 @@
                 </span></a
             >
             <a
-                v-if="isCreator() && assessment.status !== 10 && !isOffline"
+                v-if="
+                    isCreator() && assessment.status !== 10 && !isSurveyOffline
+                "
                 @click="destroy"
                 role="button"
                 class="btn btn--rounded"
@@ -109,7 +114,9 @@
                 }}</span></a
             >
             <a
-                v-if="isCreator() && assessment.status === 10 && !isOffline"
+                v-if="
+                    isCreator() && assessment.status === 10 && !isSurveyOffline
+                "
                 @click="infoToDestroy"
                 role="button"
                 class="btn btn--rounded"
@@ -146,7 +153,7 @@ export default {
     computed: {
         ...mapState({
             assessment: (state) => state.assessments.assessment,
-            isOffline: (state) => state.layout.offline,
+            isSurveyOffline: (state) => !!state.assessments.assessment.checkout,
         }),
     },
     watch: {
@@ -226,7 +233,7 @@ export default {
         },
         onClickOfflineButton() {
             if (this.hasConnection) {
-                if (this.isOffline) {
+                if (this.isSurveyOffline) {
                     this.setOnline();
                 } else {
                     this.setOffline();

--- a/components/assessment/edit/header.vue
+++ b/components/assessment/edit/header.vue
@@ -58,6 +58,12 @@
                 </template>
             </div>
         </div>
+        <p
+            v-if="wasSurveyOfflineModeInitiatedByCurrentUser"
+            class="container text-red-400 text-sm pt-1"
+        >
+            {{ $t('pages.assessments.edit.offlineSurveyWarning') }}
+        </p>
     </header>
 </template>
 
@@ -72,6 +78,9 @@ export default {
             assessment: (state) => state.assessments.assessment,
             lastEdit: (state) => moment(state.assessments.assessment.last_edit),
         }),
+        wasSurveyOfflineModeInitiatedByCurrentUser() {
+            return this.assessment.checkout === this.$auth.user.id;
+        },
     },
 };
 </script>

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -607,7 +607,8 @@
                 "optionalAttributesDescription": "Select the attributes that correspond with your Assessment",
                 "mandatoryAttribute": "Mandatory",
                 "inactiveAttribute": "Inactive attribute",
-                "activeAttribute": "Active attribute"
+                "activeAttribute": "Active attribute",
+                "offlineSurveyWarning": "Please ensure that offline edits happen in the same browser. If you switch browsers before turning the survey online again, you may lose your offline edits."
             },
             "statuses": {
                 "90": "Open",

--- a/locales/es/translations.json
+++ b/locales/es/translations.json
@@ -587,7 +587,8 @@
                 "optionalAttributesDescription": "Select the attributes that correspond with your Assessment",
                 "mandatoryAttribute": "Mandatory",
                 "inactiveAttribute": "Inactive attribute",
-                "activeAttribute": "Active attribute"
+                "activeAttribute": "Active attribute",
+                "offlineSurveyWarning": "Asegúrese de que las ediciones sin conexión se realicen en el mismo navegador. Si cambia de navegador antes de volver a poner la encuesta en línea, es posible que pierda sus ediciones fuera de línea."
             },
             "statuses": {
                 "90": "Abierto",

--- a/locales/id/translations.json
+++ b/locales/id/translations.json
@@ -587,7 +587,8 @@
                 "optionalAttributesDescription": "Select the attributes that correspond with your Assessment",
                 "mandatoryAttribute": "Mandatory",
                 "inactiveAttribute": "Inactive attribute",
-                "activeAttribute": "Active attribute"
+                "activeAttribute": "Active attribute",
+                "offlineSurveyWarning": "Harap pastikan bahwa pengeditan offline dilakukan di browser yang sama. Jika Anda berpindah browser sebelum mengubah survei menjadi online lagi, Anda mungkin kehilangan hasil edit offline Anda."
             },
             "statuses": {
                 "90": "Open",

--- a/locales/pt/translations.json
+++ b/locales/pt/translations.json
@@ -587,7 +587,8 @@
                 "optionalAttributesDescription": "Selecione os atributos que correspondem à sua Avaliação",
                 "mandatoryAttribute": "Obrigatório",
                 "inactiveAttribute": "Atributo Inativo",
-                "activeAttribute": "Atributo Ativo"
+                "activeAttribute": "Atributo Ativo",
+                "offlineSurveyWarning": "Certifique-se de que as edições off-line ocorram no mesmo navegador. Se você trocar de navegador antes de colocar a pesquisa on-line novamente, poderá perder suas edições off-line."
             },
             "statuses": {
                 "10": "Publicados",

--- a/locales/sw/translations.json
+++ b/locales/sw/translations.json
@@ -586,7 +586,8 @@
                 "optionalAttributesDescription": "Chagua sifa zinasohusiana na tathmini yako",
                 "mandatoryAttribute": "Lazima",
                 "inactiveAttribute": "Sifa isiyotumiks",
-                "activeAttribute": "Sifa inayotumika"
+                "activeAttribute": "Sifa inayotumika",
+                "offlineSurveyWarning": "Tafadhali hakikisha kuwa mabadiliko ya nje ya mtandao yanafanyika katika kivinjari sawa. Ukibadilisha vivinjari kabla ya kugeuza utafiti mtandaoni tena, unaweza kupoteza mabadiliko yako ya nje ya mtandao."
             },
             "statuses": {
                 "90": "Fungua",

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,7 +6,7 @@ export default async () => {
     const locales = [];
     const langDir = 'locales/';
     const response = await fetch(
-        'https://api.elinordata.org/v2/activelanguages/',
+        'https://dev-api.elinordata.org/v2/activelanguages/',
     );
     const apiLocales = await response.json();
 

--- a/store/assessments.js
+++ b/store/assessments.js
@@ -258,7 +258,6 @@ export const actions = {
     },
 
     async fetchAssessment(state, id) {
-        console.log('Fetching assessment');
         this.dispatch('loader/loaderState', {
             active: true,
             text: 'Getting assessment data...',


### PR DESCRIPTION
Changes:
- update state of Turn Online/Offline button for assessment survey tab so that it comes from API and can be correctly viewed by the checking out user on other machines and other browsers
- add warning text that a user can view in any browser warning that edits need to happen in all in one browser


Note it is possible to store a value in the browsers local storage indicating that that browser checked out the survey, so that we may only show warning text to the user if they use a different browser, however the current codebase has an overabundance of stored global state, and it would be better for a developer to become familiar with it to know how best to store this value per user and per assessment. This is definitely a possibility for future work if desired.


<img width="1700" alt="Screenshot 2024-12-12 at 2 53 05 PM" src="https://github.com/user-attachments/assets/8715d113-cbe9-4101-a91a-0381b743e0e4" />
