### PR TITLE
23 upload image to define ma bug fix

### DIFF
--- a/components/ma-edit-new.vue
+++ b/components/ma-edit-new.vue
@@ -850,7 +850,7 @@ export default {
         },
         assessment() {
             const countries =
-                this.assessment.management_area_countries.countries;
+                this.assessment.management_area_countries?.countries;
             if (countries && countries.length) {
                 this.geocoder.setCountries(countries.join(','));
             }


### PR DESCRIPTION
If a user uploads an image, drags the marker, and clicks 'accept' previously the app would crash. This PR fixes it. 

This fix may not get at the root of the problem, however it prevents the app from crashing due to trying to access a property on an undefined object. 