### PR TITLE
25 show cue when assessments filter is loading

### DIFF
--- a/store/assessments.js
+++ b/store/assessments.js
@@ -235,12 +235,14 @@ export const actions = {
         }
         const notHasParams = Object.keys(params).length === 0;
 
-        if (notHasParams) {
-            this.dispatch('loader/loaderState', {
-                active: true,
-                text: 'Getting assessments...',
-            });
-        }
+        const loaderText = notHasParams
+            ? 'Getting assessments...'
+            : 'Filtering assessments...';
+
+        this.dispatch('loader/loaderState', {
+            active: true,
+            text: loaderText,
+        });
 
         this.$axios
             .get('v2/assessments/', { params })
@@ -248,12 +250,10 @@ export const actions = {
                 state.commit('setAssessments', response.data);
             })
             .finally(() => {
-                if (notHasParams) {
-                    this.dispatch('loader/loaderState', {
-                        active: false,
-                        text: '',
-                    });
-                }
+                this.dispatch('loader/loaderState', {
+                    active: false,
+                    text: '',
+                });
             });
     },
 


### PR DESCRIPTION
The existing loading indicator is leveraged to indicate to the user that the filter is doing its work. 


<img width="1714" alt="Screenshot 2025-01-07 at 3 44 05 PM" src="https://github.com/user-attachments/assets/8a797514-1f6a-42e7-9abd-7bf5c7b1e47f" />
